### PR TITLE
setuptools.command.sdist.READMES does not exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from codecs import open  # To use a consistent encoding
 import setuptools
 import setuptools.command.sdist
 
-setuptools.command.sdist.READMES = tuple(list(setuptools.command.sdist.READMES) + ['README.md'])
+_old_readmes = getattr(setuptools.command.sdist, 'READMES', ())
+setuptools.command.sdist.READMES = tuple(list(_old_readmes) + ['README.md'])
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description and other data from the relevant files


### PR DESCRIPTION
I was receiving this error when installing the package from pip

```
Downloading/unpacking Flask-Celery-Helper==0.2.1
  Real name of requirement Flask-Celery-Helper is Flask-Celery-Helper
  Downloading Flask-Celery-Helper-0.2.1.tar.gz
  Running setup.py (path:/private/var/folders/wc/nv_fsy995jsfwkz47qd4560r0000gn/T/pip_build_they4kman/Flask-Celery-Helper/setup.py) egg_info for package Flask-Celery-Helper
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/private/var/folders/wc/nv_fsy995jsfwkz47qd4560r0000gn/T/pip_build_they4kman/Flask-Celery-Helper/setup.py", line 7, in <module>
        setuptools.command.sdist.READMES = tuple(list(setuptools.command.sdist.READMES) + ['README.md'])
    AttributeError: 'module' object has no attribute 'READMES'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/private/var/folders/wc/nv_fsy995jsfwkz47qd4560r0000gn/T/pip_build_they4kman/Flask-Celery-Helper/setup.py", line 7, in <module>

    setuptools.command.sdist.READMES = tuple(list(setuptools.command.sdist.READMES) + ['README.md'])

AttributeError: 'module' object has no attribute 'READMES'
```
